### PR TITLE
Remove fstab before booting from SD

### DIFF
--- a/make-flash-card-ci20-sd.sh
+++ b/make-flash-card-ci20-sd.sh
@@ -115,6 +115,9 @@ else
     -n "CI20 Linux" -d ${vmlinuxBin} ${sdMount}/boot/vmlinux.img
 fi
 
+echo "Deleting /etc/fstab"
+rm -f ${sdMount}/etc/fstab
+
 echo "SD contents:"
 ls -hl ${sdMount}/
 


### PR DESCRIPTION
The default rootfs has a NAND device in /etc/fstab.
Attempting to boot from SD with the fstab in place
causes SystemD to fall back to emergency mode - fix this.